### PR TITLE
IonRouterOutlet wants placeholder prop - bug somewhere in Ionic

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -82,7 +82,7 @@ const App: React.FC = () => {
     <GlobalDataProvider>
       <IonSplitPane contentId="main">
       <AppMenu />
-        <IonRouterOutlet id="main">
+        <IonRouterOutlet id="main" placeholder={""}>
           <Switch>
           <Route exact path="/lists" component={Lists} />
           <Route path="/items/:mode/:id" component={Items} />


### PR DESCRIPTION
Add placeholder = "" property to IonRouterOutlet. Not sure why this is needed, not in docs, but throwing a typescript error.