### PR TITLE
Add important property to items and a yellow background for important ones

### DIFF
--- a/client/src/Colors.css
+++ b/client/src/Colors.css
@@ -14,7 +14,6 @@ ion-button.button-solid, ion-button.primary-button.ion-color::part(native), ion-
 body::after {
     backdrop-filter: blur(1px);
 }
-
 /* LIGHT MODE */
 
 body::before, ion-item, ion-list-header, ion-header, ion-toolbar, ion-list,
@@ -52,6 +51,11 @@ ion-item-divider.uncategorized-color {
     border-color: #000000;
 }
 
+:root {
+    --color-itemrow-important-bg: #f5bc09;
+}
+
+
 /* DARK MODE */
 
 .ion-palette-dark {
@@ -86,4 +90,8 @@ ion-item-divider.uncategorized-color {
     ion-item-divider.uncategorized-color {
         border-color: #ffffff;
     }
+}
+
+.ion-palette-dark {
+    --color-itemrow-important-bg: #edbf2e;
 }

--- a/client/src/Colors.css
+++ b/client/src/Colors.css
@@ -52,7 +52,8 @@ ion-item-divider.uncategorized-color {
 }
 
 :root {
-    --color-itemrow-important-bg: #f5bc09;
+    --color-itemrow-important-bg: #ffcc31;
+    --color-itemrow-important-bg-hover: #ebbc2d;
 }
 
 
@@ -94,4 +95,5 @@ ion-item-divider.uncategorized-color {
 
 .ion-palette-dark {
     --color-itemrow-important-bg: #edbf2e;
+    --color-itemrow-important-bg-hover: #d3a829;
 }

--- a/client/src/components/DBSchema.ts
+++ b/client/src/components/DBSchema.ts
@@ -83,7 +83,8 @@ export interface ItemList {
     note: string,
     quantity: number,
     categoryID: string | null ,
-    uomName: string | null
+    uomName: string | null,
+    important: boolean
   }
   
 export const ItemListInit:ItemList = {
@@ -95,7 +96,8 @@ export const ItemListInit:ItemList = {
     note: "",
     quantity: 0,
     categoryID: null,
-    uomName: null
+    uomName: null,
+    important: false
   }
   
 type AttachmentData = string | Blob | Buffer;

--- a/client/src/components/DataTypes.ts
+++ b/client/src/components/DataTypes.ts
@@ -13,7 +13,8 @@ export interface ItemRow {
     uomDesc: string,
     quantityUOMDesc: string,
     hasNote: boolean,
-    completed: boolean | null
+    completed: boolean | null,
+    important: boolean
   }
 
 export type ItemRows = ItemRow[];
@@ -21,7 +22,7 @@ export type ItemRows = ItemRow[];
 export const initItemRow: ItemRow = {
     itemID: "", globalItemID: null, itemName: "",categoryID: null, categoryName: "",
     categorySeq: 0, categoryColor: DefaultColor, quantity: 0,
-    uomDesc: "", quantityUOMDesc: "", hasNote: false, completed: false
+    uomDesc: "", quantityUOMDesc: "", hasNote: false, completed: false, important: false
   }
 
 export interface CategoryRow {

--- a/client/src/components/ItemListsModal.tsx
+++ b/client/src/components/ItemListsModal.tsx
@@ -102,6 +102,11 @@ const ItemListsModal: React.FC<ModalProps> = (props: ModalProps) => {
             </IonCol>
           </IonRow>
           <IonRow>
+            <IonCol size="10">
+                <IonCheckbox aria-label="" labelPlacement="end" checked={props.modalState.itemList.important} onIonChange={(e) => props.setModalState(prevState =>({...prevState,itemList: {...prevState.itemList, important: e.detail.checked}}) )}>{t('general.important')}</IonCheckbox>
+            </IonCol>
+          </IonRow>
+          <IonRow>
             <IonCol size="9">
               <IonText>{t('itemtext.item_was_purchased_from_here')} {props.modalState.itemList.boughtCount} {t('general.times')}</IonText>
             </IonCol>

--- a/client/src/components/ItemUtilities.ts
+++ b/client/src/components/ItemUtilities.ts
@@ -197,6 +197,18 @@ export function getItemRows(itemDocs: ItemDocs, listCombinedRows: ListCombinedRo
             }
             itemRow.completed = allCompleted;
         }    
+        if (listType === RowType.list) {
+            itemRow.important = Object.prototype.hasOwnProperty.call(list, "important") ? list.important : false;
+        } else {
+            let anyImportant = false;
+            for (let i = 0; i < itemDoc.lists.length; i++) {
+                if (itemDoc.lists[i].important) {
+                    anyImportant=true;
+                    break;
+                }
+            }
+            itemRow.important = anyImportant;
+        }
         itemRows.push(itemRow);
     })
     itemRows.sort((a,b) => (
@@ -289,7 +301,8 @@ export function getCommonKey(stateItemDoc: ItemDoc, key: string, listDocs: ListD
           categoryID: (foundGlobalItem === undefined) ? null : foundGlobalItem.defaultCategoryID,
           active: true,
           completed: false,
-          stockedAt: true
+          stockedAt: true,
+          important: false
         };
         if (globalState.settings.addListOption === AddListOptions.addToAllListsAutomatically) {
           newListDoc.active = true;

--- a/client/src/components/Usehooks.tsx
+++ b/client/src/components/Usehooks.tsx
@@ -512,6 +512,7 @@ export function useAddListToAllItems() {
               newList.quantity = getCommonKey(item,"quantity",listDocs);
               newList.stockedAt = getCommonKey(item,"stockedAt",listDocs);
               newList.uomName = getCommonKey(item,"uomName",listDocs);
+              newList.important = getCommonKey(item,"important",listDocs);
               item.lists.push(newList);
               itemUpdated=true;
             }

--- a/client/src/locales/de/translation.ts
+++ b/client/src/locales/de/translation.ts
@@ -23,6 +23,7 @@ export const de_translations =
         "quantity": "Menge",
         "uom_abbrev": "ME", // Abkürzung für Maßeinheit
         "no_uom": "Keine Maßeinheit", // Keine angegebene Maßeinheit
+        "important": "Wichtig",
         "times": "Mal",
         "reset": "Zurücksetzen",
         "note": "Notiz",

--- a/client/src/locales/en/translation.ts
+++ b/client/src/locales/en/translation.ts
@@ -23,6 +23,7 @@ export const en_translations =
         "quantity": "Quantity",
         "uom_abbrev": "UoM",  // Unit of Measure Abbreviation
         "no_uom": "No UoM", // No specified unit of measure
+        "important": "Important",
         "times": "times",
         "reset": "Reset",
         "note": "Note",

--- a/client/src/locales/es/translation.ts
+++ b/client/src/locales/es/translation.ts
@@ -23,6 +23,7 @@ export const es_translations =
         "quantity": "Cantidad",
         "uom_abbrev": "UdM", // Abreviatura de Unidad de Medida
         "no_uom": "Sin UdM", // No especificó unidad de medida
+        "important": "Importante",
         "times": "veces",
         "reset": "Reiniciar",
         "note": "Nota",

--- a/client/src/locales/it/translation.ts
+++ b/client/src/locales/it/translation.ts
@@ -23,6 +23,7 @@ export const it_translations =
         "quantity": "Quantità",
         "uom_abbrev": "UdM",  // Abbreviazione Unità di Misura
         "no_uom": "Nessuna UdM", // Nessuna unità di misura specificata
+        "important": "Importante",
         "times": "volte",
         "reset": "Resetta",
         "note": "Nota",

--- a/client/src/pages/Item.tsx
+++ b/client/src/pages/Item.tsx
@@ -1,4 +1,4 @@
-import { IonContent, IonPage, IonButton, IonList, IonInput, IonItem,
+import { IonContent, IonPage, IonButton, IonList, IonInput, IonCheckbox, IonItem,
   IonSelect, IonIcon, 
   IonSelectOption, useIonAlert,useIonToast, IonTextarea, IonGrid, IonRow, IonCol, IonText, IonCard,
   IonCardSubtitle, NavContext, IonButtons, IonToolbar, IonImg, IonFooter } from '@ionic/react';
@@ -500,6 +500,9 @@ const Item: React.FC = () => {
                     </IonCol>
                   </IonRow>
                 </IonGrid>
+              </IonItem>
+              <IonItem key="important">
+                <IonCheckbox aria-label="" labelPlacement="end" checked={getCommonKey(stateItemDoc,"important",listDocs)} onIonChange={(e) => updateAllKey("important",e.detail.checked)}>{t('general.important')}</IonCheckbox>
               </IonItem>
               <IonItem key="note">
                 <IonTextarea label={t("general.note") as string} labelPlacement="stacked" placeholder={t("general.item_note") as string} inputMode='text' debounce={100} rows={4} onIonInput={(ev) => updateAllKey("note",String(ev.detail.value))} value={getCommonKey(stateItemDoc,"note",listDocs)}>   

--- a/client/src/pages/Items.css
+++ b/client/src/pages/Items.css
@@ -36,7 +36,7 @@ ion-item.itemrow-outer.itemrow-important {
 }
 
 ion-item.itemrow-outer.itemrow-important::part(native) {
-    background: var(--color-itemrow-important-bg);
+    background: none;
 }
 
 ion-item.itemrow-outer.itemrow-important ion-item.itemrow-inner {
@@ -44,12 +44,27 @@ ion-item.itemrow-outer.itemrow-important ion-item.itemrow-inner {
 }
 
 ion-item.itemrow-outer.itemrow-important ion-item.itemrow-inner::part(native) {
-    background: var(--color-itemrow-important-bg);
     color: #333;
 }
 
 .ion-palette-dark ion-item.itemrow-outer.itemrow-important {
     background: var(--color-itemrow-important-bg);
+}
+
+ion-item.itemrow-outer.itemrow-important:hover {
+    background: var(--color-itemrow-important-bg-hover);
+    --background: var(--color-itemrow-important-bg-hover);
+    --background-activated: none;
+    --background-focused: none;
+    --background-hover: none;
+}
+
+ion-item.itemrow-outer.itemrow-important:hover ion-item.itemrow-inner {
+    background: var(--color-itemrow-important-bg-hover);
+    --background: var(--color-itemrow-important-bg-hover);
+    --background-activated: none;
+    --background-focused: none;
+    --background-hover: none;
 }
 
 ion-checkbox.item-on-list {

--- a/client/src/pages/Items.css
+++ b/client/src/pages/Items.css
@@ -31,6 +31,27 @@ ion-item.itemrow-outer {
     transition:padding-block 200ms ease-in-out;
 }
 
+ion-item.itemrow-outer.itemrow-important {
+    background: var(--color-itemrow-important-bg);
+}
+
+ion-item.itemrow-outer.itemrow-important::part(native) {
+    background: var(--color-itemrow-important-bg);
+}
+
+ion-item.itemrow-outer.itemrow-important ion-item.itemrow-inner {
+    background: var(--color-itemrow-important-bg);
+}
+
+ion-item.itemrow-outer.itemrow-important ion-item.itemrow-inner::part(native) {
+    background: var(--color-itemrow-important-bg);
+    color: #333;
+}
+
+.ion-palette-dark ion-item.itemrow-outer.itemrow-important {
+    background: var(--color-itemrow-important-bg);
+}
+
 ion-checkbox.item-on-list {
     margin-right: 1.25rem;
 }

--- a/client/src/pages/Items.tsx
+++ b/client/src/pages/Items.tsx
@@ -679,7 +679,7 @@ const Items: React.FC<HistoryProps> = () => {
     }
     const rowVisible = getCategoryExpanded(item.categoryID,Boolean(item.completed));
     currentRows.push(
-      <IonItem className={"itemrow-outer "+(rowVisible ? "itemrow-display" : "itemrow-hidden")} key={"itemouter"+pageState.itemRows[i].itemID} >
+      <IonItem className={"itemrow-outer "+(rowVisible ? "itemrow-display" : "itemrow-hidden")+(item.important ? " itemrow-important" : "")} key={"itemouter"+pageState.itemRows[i].itemID} >
         <IonCheckbox key={"itemcheckbox"+pageState.itemRows[i].itemID} aria-label=""
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           onIonChange={(e: CustomEvent<CheckboxChangeEventDetail>) => {if (!doingUpdate.current) { (e.target as any).disabled = true; doingUpdate.current=true; completeItemRowStub(item.itemID,e)}}}

--- a/client/src/schema-examples.txt
+++ b/client/src/schema-examples.txt
@@ -122,7 +122,8 @@ CHANGED Item  (now tied at a master level to listGroup, so Banana in "Copley Gro
             note: "At Acme, pickup the yellower bananas",
             quantity: 2
             categoryID: "xxx" // Produce
-            uomName: "BN" // bunch
+            uomName: "BN" // bunch,
+            important: "true"
         },
         {   listID: "yyy" // Giant Eagle
             active: "true"
@@ -132,7 +133,8 @@ CHANGED Item  (now tied at a master level to listGroup, so Banana in "Copley Gro
             note: "At Giant eagle, get the cheaper green bunch",
             quantity: 1
             categoryID: "yyy" // Fruit
-            uomName: "EA" // Each
+            uomName: "EA" // Each,
+            important: "false"
         }
     }
 


### PR DESCRIPTION
One thing I missed from a previous shopping list app is marking items as important, so I added it.
The important property is per-list, but as with the quantity for example I also added a checkbox that changes the value for all lists of the item.
Important items have a yellow-ish background on the lists they are marked as important and on the list group if they are important on at least one list.

For the background colors (light and dark) I chose the same color with which the lists are marked in the item edit page to see which have different settings. Since I couldn't find that color, I defined two new ones in Colors.css.
What I didn't achieve is a background hover color, everytime I tried the hover color didn't cover everything, so I left it out for now. If you know how to do that, please let me know or implement it directly, this is my first time working with CSS.